### PR TITLE
Disabling changelog tests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the issue on centos/red hat where the MODE contains a trailing `.`.
 
+### Removed
+
+- Disabling changelog tests because of the way the private repo fetches and errors on the `git diff`.
+
 ## [0.2.0] - 2021-05-25
 
 ### Added

--- a/build.yaml
+++ b/build.yaml
@@ -92,6 +92,7 @@ DscTest:
         Tag:
         ExcludeTag:
           - Common Tests - New Error-Level Script Analyzer Rules
+          - Changelog
           # - Common Tests - Validate Example Files
       Output:
         Verbosity: Detailed


### PR DESCRIPTION


#### Pull Request (PR) description

Disabling the Changelog hqrm tests, because there are some issues with the git fetch.
As we have 2 repos with "different" (albeit similar) commit history, the git diff command tends to error.
Until I have a good understanding and workaround for this I've decided to remove the test for that private build, but we'll try to keep it for the public nxtools build (only in GH) for PRs.

#### This Pull Request (PR) fixes the following issues

None

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
