### PR TITLE
nxPackage: Fix Set-operation hanging for apt-packages 

### DIFF
--- a/source/Classes/1.DscResources/04.nxPackage.ps1
+++ b/source/Classes/1.DscResources/04.nxPackage.ps1
@@ -115,6 +115,7 @@ class nxPackage
             # Anyway, whether absent or present at wrong version, we can only try to install at specific version
             $installnxPackageParams = @{
                 Name = $this.Name
+                Force = $true
             }
 
             if (-not [string]::IsNullOrEmpty)

--- a/source/Public/Packages/Apt/Install-nxAptPackage.ps1
+++ b/source/Public/Packages/Apt/Install-nxAptPackage.ps1
@@ -13,7 +13,11 @@ function Install-nxAptPackage
         [ValidateNotNullOrEmpty()]
         [string]
         # Specifc Version of a package that you want to find in the Cached list of packages.
-        $Version
+        $Version,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $Force
     )
 
     begin
@@ -25,6 +29,12 @@ function Install-nxAptPackage
     {
         # apt-get install
         $aptGetInstallParams = @('install','--quiet')
+
+        if ($PSBoundParameters.ContainsKey('Force') -and $PSBoundParameters['Force'])
+        {
+            $aptGetInstallParams += @('--yes')
+        }
+
         foreach ($packageName in $Name)
         {
             $packageToInstall = $packageName

--- a/source/Public/Packages/Install-nxPackage.ps1
+++ b/source/Public/Packages/Install-nxPackage.ps1
@@ -15,7 +15,11 @@ function Install-nxPackage
 
         [Parameter()]
         [nxSupportedPackageType[]]
-        $PackageType = (Get-nxSupportedPackageType)
+        $PackageType = (Get-nxSupportedPackageType),
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $Force
     )
 
     begin
@@ -29,6 +33,7 @@ function Install-nxPackage
 
     end
     {
+
         if ($PSBoundParameters.ContainsKey('PackageType'))
         {
             $null = $PSBoundParameters.Remove('PackageType')


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project
    is greatly appreciated!

    Have you checked the [CONTRIBUTING](CONTRIBUTING.md) document?
-->

#### Pull Request (PR) description

<!--
    Replace this comment block with a description of your PR. Also, make sure you have updated the
    CHANGELOG.md, see the task list below. An entry in the CHANGELOG.md is mandatory for all PRs.
-->

This PR adds a -Force parameter to Install-nxAptPackage and Install-nxPackage to make it possible to supply the confirmation parameter `--yes` to `apt install` when using the commands interactively.
It also adds `Force = $true` in the `nxPackage` resource in order to suppress the confirmation promt in unattended DSC invocations.


#### This Pull Request (PR) fixes the following issues

- Fixes #19 

#### Task list

- [ x ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ x ] Resource documentation added/updated in README.md.
- [ x ] Comment-based help added/updated.
- [ x ] Localization strings added/updated in all localization files as appropriate.
- [ x ] Examples appropriately added/updated.
- [ x ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ x ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ x ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
