### PR TITLE
Fix nxUser FullName and Description bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed nxUser Set function failure when FullName and Description are populated.
+
+## [1.0.0] - 2023-05-25
+
 ### Added
 
 - Added PS DSC module dependency and release notes to README.md, including Microsoft copyright.
+
+### Fixed
+
+- Fixed HQRM style non-compliance.
+- Fixed issue with nxTools when reporting compliance but package version issue (thanks to Jan Egil Ring).
+- Fixed an issue with the nxFile Test function where it was always returning False.
+- Fixed nxFileLine causing an unknown propertyName error.
+
+## [0.4.0-preview0001] - 2023-03-16
+
+### Added
+
 - Added KitchenCI tests for the packages on ubuntu-18.04, debian-10, and centos-7.5.
 - Added the `Functions` test suite for Kitchen-Pester.
 - Added `[nxFileLine]` and `[nxFileContentReplace]` DSC Resources to manage file content.
@@ -42,10 +60,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed the issue on centos/red hat where the MODE contains a trailing `.`.
-- Fixed HQRM style non-compliance.
-- Fixed issue with nxTools when reporting compliance but package version issue (thanks to Jan Egil Ring).
-- Fixed an issue with the nxFile Test function where it was always returning False.
-- Fixed nxFileLine causing an unknown propertyName error.
+- Relying on ModuleVersion from Module manifest.
+
+### Changed
+
+- Setting up official pipeline.
 
 ### Removed
 

--- a/source/Classes/1.DscResources/03.nxUser.ps1
+++ b/source/Classes/1.DscResources/03.nxUser.ps1
@@ -217,7 +217,7 @@ class nxUser
                 {
                     $newNxLocalUserParam.Add(
                         'UserInfo',
-                        ('{0},,,,{1},' -f $this.FullName, $this.Description)
+                        ('{0},,,,{1}' -f $this.FullName, $this.Description)
                     )
                 }
 

--- a/source/Public/usersAndGroups/New-nxLocalUser.ps1
+++ b/source/Public/usersAndGroups/New-nxLocalUser.ps1
@@ -193,7 +193,7 @@ function New-nxLocalUser
 
         if ($PSBoundParameters.ContainsKey('UserInfo') -and $PSBoundParameters['UserInfo'])
         {
-            $userAddParams += @('-c', $UserInfo)
+            $userAddParams += @('-c', ('"{0}"' -f $UserInfo))
         }
 
         if ($PSBoundParameters.ContainsKey('ExpireOn') -and $PSBoundParameters['ExpireOn'])


### PR DESCRIPTION
#### Pull Request (PR) description

Fixed bugs with nxUser where if FullName and Description fields are provided in the mof file of a custom package, Start-GuestConfigurationPackageRemediation fails because the useradd command that is created is invalid.

**Command before fix**: useradd -d "/home/test" -c test user,,,,Some description, -U

There are two problems with this command.

1. The COMMENT string, after the -c flag, needs to be in quotes. Otherwise, we see an error: "Missing expression after ',' in pipeline element."
2. There is an extra comma after the Description because when parsing /etc/passwd, nxLocalUser is expecting 5 comma-separated GECOS fields, not 6.

**Command after fix**: useradd -d "/home/test" -c "test user,,,,Some description" -U

#### This Pull Request (PR) fixes the following issues

None

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).