### PR TITLE
Add nxScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - DscResource:
-    - `nxScript`: Simple resource for executing scripts on Linux machines.
+    - `nxScript`: Simple resource for executing scripts.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - DscResource:
-    - `nxScript`: Simple resource for executing scripts.
+    - `nxScript`: Simple resource for executing scripts in PowerShell 7.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- DscResource:
+    - `nxScript`: Simple resource for executing scripts on Linux machines.
+
 ### Fixed
 
 - Fixed nxUser Set function failure when FullName and Description are populated.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Here are the public commands available.
 - `nxPackage`: Audit (for now) whether a package is installed or not in a system (currently supports apt only).
 - `nxFileLine`: Ensure an exact line is present/absent in a file, and remediate by appending, inserting, deleting as needed.
 - `nxFileContentReplace`: Replace the content in a file if a pattern is found.
+- `nxScript`: Simple resource for executing scripts.
 
 ## Guest Configuration Packages
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Here are the public commands available.
 - `nxPackage`: Audit (for now) whether a package is installed or not in a system (currently supports apt only).
 - `nxFileLine`: Ensure an exact line is present/absent in a file, and remediate by appending, inserting, deleting as needed.
 - `nxFileContentReplace`: Replace the content in a file if a pattern is found.
-- `nxScript`: Simple resource for executing scripts.
+- `nxScript`: Simple resource for executing scripts in PowerShell 7.
 
 ## Guest Configuration Packages
 

--- a/source/Classes/1.DscResources/08.nxScript.ps1
+++ b/source/Classes/1.DscResources/08.nxScript.ps1
@@ -19,7 +19,7 @@ class nxScript
         {
             $Reason = [Reason]::new()
             $Reason.Code = "Script:Script:GetScriptNotDefined"
-            $Reason.Phrase = "The GetScript script block was not defined"
+            $Reason.Phrase = "Cannot determine reason for non-compliance. Please define Reasons in the hashtable returned from the GetScript script block to return reasons for non-compliance."
             $this.Reasons = @($Reason)
             return $this
         }

--- a/source/Classes/1.DscResources/08.nxScript.ps1
+++ b/source/Classes/1.DscResources/08.nxScript.ps1
@@ -15,9 +15,10 @@ class nxScript
 
     [nxScript] Get()
     {
-        if (-not $this.GetScript)
+        if ([string]::IsNullOrEmpty($this.GetScript))
         {
             # The GetScript script block was not defined
+            $this.Reasons = $null
             return $this
         }
 
@@ -57,7 +58,7 @@ class nxScript
 
     [void] Set()
     {
-        if (-not $this.SetScript)
+        if ([string]::IsNullOrEmpty($this.SetScript))
         {
             # The SetScript script block was not defined
             return
@@ -93,14 +94,14 @@ class nxScript
 
         if (-not $GetScriptOutput.ContainsKey("Reasons"))
         {
-            Write-Verbose -Message "The hashtable does not have a Reasons key"
+            Write-Verbose -Message "The hashtable returned by GetScript does not contain a Reasons key"
             return $false
         }
 
         $outputReasons = $GetScriptOutput["Reasons"]
         if ($outputReasons.Count -eq 0)
         {
-            Write-Verbose -Message "The Reasons list is empty"
+            Write-Verbose -Message "The Reasons list returned by GetScript is empty"
             return $false
         }
 
@@ -108,7 +109,7 @@ class nxScript
         {
             if ($outputReason -isnot [Reason])
             {
-                Write-Verbose -Message "One of the Reasons is not a Reason object"
+                Write-Verbose -Message "One of the Reasons returned by GetScript is not a Reason object"
                 return $false
             }
         }

--- a/source/Classes/1.DscResources/08.nxScript.ps1
+++ b/source/Classes/1.DscResources/08.nxScript.ps1
@@ -23,7 +23,6 @@ class nxScript
         $currentState.GetScript = $this.GetScript
         $currentState.TestScript = $this.TestScript
         $currentState.SetScript = $this.SetScript
-        $currentState.Reasons = @([Reason]::new())
         if ($isValid)
         {
             $currentState.Reasons = $invokeScriptResult.Reasons
@@ -39,11 +38,13 @@ class nxScript
 
         if ($invokeScriptResult -is [System.Management.Automation.ErrorRecord])
         {
+            Write-Verbose -Message "TestScript returned an error."
             return $false
         }
 
         if ($null -eq $invokeScriptResult -or -not ($invokeScriptResult -is [System.Boolean]))
         {
+            Write-Verbose -Message "TestScript output is not a Boolean."
             return $false
         }
 
@@ -76,22 +77,26 @@ class nxScript
     {
         if ($GetScriptOutput -is [System.Management.Automation.ErrorRecord])
         {
+            Write-Verbose -Message "GetScript returned an error."
             return $false
         }
 
         if ($GetScriptOutput -isnot [System.Collections.Hashtable])
         {
+            Write-Verbose -Message "GetScript output is not a hashtable."
             return $false
         }
 
         if (-not $GetScriptOutput.ContainsKey('Reasons'))
         {
+            Write-Verbose -Message "GetScript output does not contain a 'Reasons' key."
             return $false
         }
 
         $outputReasons = $GetScriptOutput['Reasons']
         if ($outputReasons.Count -eq 0)
         {
+            Write-Verbose -Message "GetScript output does not contain any 'Reasons'."
             return $false
         }
 
@@ -99,11 +104,13 @@ class nxScript
         {
             if ($outputReason -isnot [System.Collections.Hashtable])
             {
+                Write-Verbose -Message "GetScript reason is not a hashtable."
                 return $false
             }
 
             if (-not $outputReason.ContainsKey('Code') -or -not $outputReason.ContainsKey('Phrase'))
             {
+                Write-Verbose -Message "GetScript reason does not have a 'Code' key or a 'Phrase' key."
                 return $false
             }
         }

--- a/source/Classes/1.DscResources/08.nxScript.ps1
+++ b/source/Classes/1.DscResources/08.nxScript.ps1
@@ -17,8 +17,10 @@ class nxScript
     {
         if ([string]::IsNullOrEmpty($this.GetScript))
         {
-            # The GetScript script block was not defined
-            $this.Reasons = $null
+            $Reason = [Reason]::new()
+            $Reason.Code = "Script:Script:GetScriptNotDefined"
+            $Reason.Phrase = "The GetScript script block was not defined"
+            $this.Reasons = @($Reason)
             return $this
         }
 

--- a/source/Classes/1.DscResources/08.nxScript.ps1
+++ b/source/Classes/1.DscResources/08.nxScript.ps1
@@ -1,0 +1,113 @@
+[DscResource()]
+class nxScript
+{
+    [DscProperty(Key)]
+    [System.String] $GetScript
+
+    [DscProperty(Key)]
+    [System.String] $TestScript
+
+    [DscProperty(Key)]
+    [System.String] $SetScript
+
+    [DscProperty()]
+    [Reason[]] $Reasons
+
+    [nxScript] Get()
+    {
+        $scriptBlock = [System.Management.Automation.ScriptBlock]::Create($this.GetScript)
+        $invokeScriptResult = $this.InvokeScript($scriptBlock)
+        $isValid = $this.TestGetScriptOutput($invokeScriptResult)
+
+        $currentState = [nxScript]::new()
+        $currentState.GetScript = $this.GetScript
+        $currentState.TestScript = $this.TestScript
+        $currentState.SetScript = $this.SetScript
+        $currentState.Reasons = @([Reason]::new())
+        if ($isValid)
+        {
+            $currentState.Reasons = $invokeScriptResult.Reasons
+        }
+
+        return $currentState
+    }
+
+    [bool] Test()
+    {
+        $scriptBlock = [System.Management.Automation.ScriptBlock]::Create($this.TestScript)
+        $invokeScriptResult = $this.InvokeScript($scriptBlock)
+
+        if ($invokeScriptResult -is [System.Management.Automation.ErrorRecord])
+        {
+            return $false
+        }
+
+        if ($null -eq $invokeScriptResult -or -not ($invokeScriptResult -is [System.Boolean]))
+        {
+            return $false
+        }
+
+        return $invokeScriptResult
+    }
+
+    [void] Set()
+    {
+        $scriptBlock = [System.Management.Automation.ScriptBlock]::Create($this.SetScript)
+        $this.InvokeScript($scriptBlock)
+    }
+
+    [System.Object] InvokeScript([System.Management.Automation.ScriptBlock] $ScriptBlock)
+    {
+        $scriptResult = $null
+        try
+        {
+            $scriptResult = & $ScriptBlock
+        }
+        catch
+        {
+            # Surfacing the error thrown by the execution of the script
+            $scriptResult = $_
+        }
+
+        return $scriptResult
+    }
+
+    [bool] TestGetScriptOutput([System.Object] $GetScriptOutput)
+    {
+        if ($GetScriptOutput -is [System.Management.Automation.ErrorRecord])
+        {
+            return $false
+        }
+
+        if ($GetScriptOutput -isnot [System.Collections.Hashtable])
+        {
+            return $false
+        }
+
+        if (-not $GetScriptOutput.ContainsKey('Reasons'))
+        {
+            return $false
+        }
+
+        $outputReasons = $GetScriptOutput['Reasons']
+        if ($outputReasons.Count -eq 0)
+        {
+            return $false
+        }
+
+        foreach ($outputReason in $outputReasons)
+        {
+            if ($outputReason -isnot [System.Collections.Hashtable])
+            {
+                return $false
+            }
+
+            if (-not $outputReason.ContainsKey('Code') -or -not $outputReason.ContainsKey('Phrase'))
+            {
+                return $false
+            }
+        }
+
+        return $true
+    }
+}

--- a/source/Examples/Resources/nxScript/1-CreateFileNxScript.ps1
+++ b/source/Examples/Resources/nxScript/1-CreateFileNxScript.ps1
@@ -80,9 +80,7 @@ configuration CreateFileNxScript
             }
         }
         SetScript = {
-            $streamWriter = New-Object -TypeName 'System.IO.StreamWriter' -ArgumentList @($using:FilePath)
-            $streamWriter.WriteLine($using:FileContent)
-            $streamWriter.Close()
+            $null = Set-Content -Path $using:FilePath -Value $using:FileContent
         }
     }
 }

--- a/source/Examples/Resources/nxScript/CreateFileNxScript.ps1
+++ b/source/Examples/Resources/nxScript/CreateFileNxScript.ps1
@@ -1,0 +1,63 @@
+configuration CreateFileNxScript
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $FilePath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $FileContent
+    )
+
+    Import-DscResource -ModuleName 'nxtools'
+
+    nxScript MyScript
+    {
+        GetScript = {
+            $Reason = @{
+                Code = "Script:Script:FileMissing"
+                Phrase = "File does not exist"
+            }
+
+            if (Test-Path -Path $using:FilePath)
+            {
+                $text = $(Get-Content -Path $using:FilePath -Raw).Trim()
+                if ($text -eq $using:FileContent)
+                {
+                    $Reason.Code = "Script:Script:Success"
+                    $Reason.Phrase = "File exists with correct content"
+                }
+                else
+                {
+                    $Reason.Code = "Script:Script:ContentMissing"
+                    $Reason.Phrase = "File exists but has incorrect content"
+                }
+            }
+
+            return @{
+                Reasons = @($Reason)
+            }
+        }
+        SetScript = {
+            $streamWriter = New-Object -TypeName 'System.IO.StreamWriter' -ArgumentList @($using:FilePath)
+            $streamWriter.WriteLine($using:FileContent)
+            $streamWriter.Close()
+        }
+        TestScript = {
+            if (Test-Path -Path $using:FilePath)
+            {
+                $text = $(Get-Content -Path $using:FilePath -Raw).Trim()
+                return $text -eq $using:FileContent
+            }
+            else
+            {
+                return $false
+            }
+        }
+    }
+}

--- a/source/Examples/Resources/nxScript/CreateFileNxScript.ps1
+++ b/source/Examples/Resources/nxScript/CreateFileNxScript.ps1
@@ -19,10 +19,9 @@ configuration CreateFileNxScript
     nxScript MyScript
     {
         GetScript = {
-            $Reason = @{
-                Code = "Script:Script:FileMissing"
-                Phrase = "File does not exist"
-            }
+            $Reason = [Reason]::new()
+            $Reason.Code = "Script:Script:FileMissing"
+            $Reason.Phrase = "File does not exist"
 
             if (Test-Path -Path $using:FilePath)
             {
@@ -43,11 +42,6 @@ configuration CreateFileNxScript
                 Reasons = @($Reason)
             }
         }
-        SetScript = {
-            $streamWriter = New-Object -TypeName 'System.IO.StreamWriter' -ArgumentList @($using:FilePath)
-            $streamWriter.WriteLine($using:FileContent)
-            $streamWriter.Close()
-        }
         TestScript = {
             if (Test-Path -Path $using:FilePath)
             {
@@ -58,6 +52,11 @@ configuration CreateFileNxScript
             {
                 return $false
             }
+        }
+        SetScript = {
+            $streamWriter = New-Object -TypeName 'System.IO.StreamWriter' -ArgumentList @($using:FilePath)
+            $streamWriter.WriteLine($using:FileContent)
+            $streamWriter.Close()
         }
     }
 }

--- a/source/Examples/Resources/nxScript/CreateFileNxScript.ps1
+++ b/source/Examples/Resources/nxScript/CreateFileNxScript.ps1
@@ -1,3 +1,29 @@
+<#
+    .DESCRIPTION
+        This example shows how to create a file with [nxScript].
+
+    .NOTES
+        Because the resources are class based, you can also test the resource this way:
+
+        using module nxtools # assuming it's available via $Env:PSModulePath.
+
+        $rsrc = [nxScript]@{
+            GetScript = {
+                # Implementation...
+            }
+            TestScript = {
+                # Implementation...
+            }
+            SetScript = {
+                # Implementation...
+            }
+        }
+
+        $rsrc.Get().Reasons
+        $rsrc.Set()
+        $rsrc.Get()
+#>
+
 configuration CreateFileNxScript
 {
     [CmdletBinding()]

--- a/tests/Unit/Classes/DscResources/nxScript.tests.ps1
+++ b/tests/Unit/Classes/DscResources/nxScript.tests.ps1
@@ -8,7 +8,7 @@ Describe "nxScript resource for executing scripts in PowerShell 7" {
             $result | Should -Be $nxScript
             $result.Reasons.Count | should -Be 1
             $result.Reasons[0].Code | Should -Be "Script:Script:GetScriptNotDefined"
-            $result.Reasons[0].Phrase | Should -Be "The GetScript script block was not defined"
+            $result.Reasons[0].Phrase | Should -Be "Cannot determine reason for non-compliance. Please define Reasons in the hashtable returned from the GetScript script block to return reasons for non-compliance."
         }
     }
 

--- a/tests/Unit/Classes/DscResources/nxScript.tests.ps1
+++ b/tests/Unit/Classes/DscResources/nxScript.tests.ps1
@@ -1,0 +1,111 @@
+using module nxtools
+
+Describe "nxScript resource for executing scripts in PowerShell 7" {
+    Context "When GetScript is not defined" {
+        It "Should return the nxScript object" {
+            $nxScript = [nxScript]::new()
+            $result = $nxScript.Get()
+            $result | Should -Be $nxScript
+            $result.Reasons.Count | should -Be 0
+        }
+    }
+
+    Context "When GetScript is defined" {
+        It "Should invoke the GetScript script block" {
+            $nxScript = [nxScript]::new()
+            $nxScript.GetScript = {
+                $Reason = [Reason]::new()
+                $Reason.Code = "Script:Script:Reason"
+                $Reason.Phrase = "Reason"
+                return @{
+                    Reasons = @($Reason)
+                }
+            }
+
+            $result = $nxScript.Get()
+            $result.Reasons.Count | Should -Be 1
+            $result.Reasons[0].Code | Should -Be "Script:Script:Reason"
+            $result.Reasons[0].Phrase | Should -Be "Reason"
+        }
+
+        It "Should throw an error if GetScript returns an error" {
+            $nxScript = [nxScript]::new()
+            $nxScript.GetScript = { throw "Error" }
+            { $nxScript.Get() } | Should -Throw "The GetScript script block returned an error: Error."
+        }
+
+        It "Should throw an error if GetScript does not return a hashtable" {
+            $nxScript = [nxScript]::new()
+            $nxScript.GetScript = { return "not a hashtable" }
+            { $nxScript.Get() } | Should -Throw "The GetScript script block must return a hashtable that contains a non-empty list of Reason objects under the Reasons key."
+        }
+
+        It "Should throw an error if GetScript does not return a Reasons key" {
+            $nxScript = [nxScript]::new()
+            $nxScript.GetScript = {
+                return @{
+                    NotReasons = @()
+                }
+            }
+
+            { $nxScript.Get() } | Should -Throw "The GetScript script block must return a hashtable that contains a non-empty list of Reason objects under the Reasons key."
+        }
+
+        It "Should throw an error if GetScript returns an empty Reasons list" {
+            $nxScript = [nxScript]::new()
+            $nxScript.GetScript = {
+                return @{
+                    Reasons = @()
+                }
+            }
+
+            { $nxScript.Get() } | Should -Throw "The GetScript script block must return a hashtable that contains a non-empty list of Reason objects under the Reasons key."
+        }
+
+        It "Should throw an error if GetScript returns a non-Reason object in the Reasons list" {
+            $nxScript = [nxScript]::new()
+            $nxScript.GetScript = {
+                return @{
+                    Reasons = @(1)
+                }
+            }
+
+            { $nxScript.Get() } | Should -Throw "The GetScript script block must return a hashtable that contains a non-empty list of Reason objects under the Reasons key."
+        }
+    }
+
+    Context "wWhen TestScript is defined" {
+        It "Should invoke the TestScript script block" {
+            $nxScript = [nxScript]::new()
+            $nxScript.TestScript = { return $true }
+            $nxScript.Test() | Should -Be $true
+        }
+
+        It "Should throw an error if TestScript returns an error" {
+            $nxScript = [nxScript]::new()
+            $nxScript.TestScript = { throw "Error" }
+            { $nxScript.Test() } | Should -Throw "The TestScript script block returned an error: Error."
+        }
+
+        It "Should throw an error if TestScript does not return a Boolean" {
+            $nxScript = [nxScript]::new()
+            $nxScript.TestScript = { return "not a boolean" }
+            { $nxScript.Test() } | Should -Throw "The TestScript script block must return a Boolean."
+        }
+    }
+
+    Context "When SetScript is not defined" {
+        It "Should not throw an error" {
+            $nxScript = [nxScript]::new()
+            { $nxScript.Set() } | Should -Not -Throw
+        }
+    }
+
+    Context "When SetScript is defined" {
+        It "Should invoke the SetScript script block" {
+            $nxScript = [nxScript]::new()
+            $nxScript.SetScript = { return $null }
+            { $nxScript.Set() } | Should -Not -Throw
+        }
+    }
+}

--- a/tests/Unit/Classes/DscResources/nxScript.tests.ps1
+++ b/tests/Unit/Classes/DscResources/nxScript.tests.ps1
@@ -2,11 +2,13 @@ using module nxtools
 
 Describe "nxScript resource for executing scripts in PowerShell 7" {
     Context "When GetScript is not defined" {
-        It "Should return the nxScript object" {
+        It "Should return the nxScript object with a default Reason" {
             $nxScript = [nxScript]::new()
             $result = $nxScript.Get()
             $result | Should -Be $nxScript
-            $result.Reasons.Count | should -Be 0
+            $result.Reasons.Count | should -Be 1
+            $result.Reasons[0].Code | Should -Be "Script:Script:GetScriptNotDefined"
+            $result.Reasons[0].Phrase | Should -Be "The GetScript script block was not defined"
         }
     }
 


### PR DESCRIPTION
#### Pull Request (PR) description

Added a nxScript resource similar to the one found in the nx module. Currently supports three parameters, GetScript, TestScript, and SetScript. GetScript and SetScript are optional parameters.

- GetScript: Must return a hashtable that contains a non-empty list of Reason objects under the Reasons key. Reasons can be used to explain why a resource is not compliant. If Reasons are not returned in the right format, for example, if a hashtable is not returned or if Reasons are in the wrong format, Get() will throw an error. If not defined, a default Reason will be returned: "Cannot determine reason for non-compliance. Please define Reasons in the hashtable returned from the GetScript script block to return reasons for non-compliance."
- TestScript: Must return a Boolean. Evaluates whether the machine is in the correct state. If a Boolean is not returned, Test() will throw an error.
- SetScript: Executed if TestScript returns False.

#### This Pull Request (PR) fixes the following issues

- Fixes #22 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
