### PR TITLE
Fix nxService unknown propertyName error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed nxService causing an unknown propertyName error.
+
+## [1.1.0] - 2023-07-18
+
 ### Added
 
 - DscResource:

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Here are the public commands available.
 - `nxPackage`: Audit (for now) whether a package is installed or not in a system (currently supports apt only).
 - `nxFileLine`: Ensure an exact line is present/absent in a file, and remediate by appending, inserting, deleting as needed.
 - `nxFileContentReplace`: Replace the content in a file if a pattern is found.
+- `nxService`: Simple resource for managing services on a Linux node (currently supports systemd only).
 - `nxScript`: Simple resource for executing scripts in PowerShell 7.
 
 ## Guest Configuration Packages

--- a/source/Classes/1.DscResources/07.nxService.ps1
+++ b/source/Classes/1.DscResources/07.nxService.ps1
@@ -15,6 +15,9 @@ class nxService
     [DscProperty()] # Write Only
     [nxInitSystem] $Controller = (Get-nxInitSystem)
 
+    [DscProperty(NotConfigurable)]
+    [Reason[]] $Reasons
+
     hidden [void] SetNxServiceProperties([IDictionary] $Definition)
     {
         if ($Definition.keys -notcontains 'Name')
@@ -30,7 +33,12 @@ class nxService
 
     [nxService] Get()
     {
-        $currentState = Get-nxService -Name $this.Name
+        $nxService = Get-nxService -Name $this.Name
+        $currentState = [nxService]::new()
+        $currentState.Name = $nxService.Name
+        $currentState.Enabled = $nxService.Enabled
+        $currentState.State = $nxService.State
+        $currentState.Controller = $this.Controller
 
         if (-not $currentState)
         {

--- a/source/Classes/4.Services/nxSystemdService.ps1
+++ b/source/Classes/4.Services/nxSystemdService.ps1
@@ -9,8 +9,6 @@ class nxSystemdService : nxService
     [string] $Status # Specific to Systemctl
     [string] $Description
 
-    [Reason[]] $Reasons
-
     nxSystemdService()
     {
         # default ctor

--- a/tests/Unit/Classes/DscResources/nxService.tests.ps1
+++ b/tests/Unit/Classes/DscResources/nxService.tests.ps1
@@ -1,0 +1,95 @@
+using module nxtools
+
+$script:testService = "myTestService.service" # Mock service for testing
+
+Describe "nxService resource for managing services on a Linux node" {
+    BeforeAll {
+        Mock -ModuleName 'nxtools' -CommandName 'Invoke-NativeCommand' -ParameterFilter {
+            $expected = @('is-enabled', $testService)
+            $diff = Compare-Object $Parameters $expected
+            return $Executable -eq "systemctl" -and $diff.Count -eq 0
+        } -MockWith { "enabled" }
+
+        Mock -ModuleName 'nxtools' -CommandName 'Get-nxInitSystem' -MockWith { [nxInitSystem]::systemd }
+        Mock -ModuleName 'nxtools' -CommandName 'Get-Command' -ParameterFilter { $Name -eq "systemctl" } -MockWith { $true }
+    }
+
+    Context "When the service is running" {
+        BeforeAll {
+            Mock -ModuleName 'nxtools' -CommandName 'Invoke-NativeCommand' -ParameterFilter {
+                $expected = @('list-units', '--type=service', '--no-legend', '--all', '--no-pager', $testService)
+                $diff = Compare-Object $Parameters $expected
+                return $Executable -eq "systemctl" -and $diff.Count -eq 0
+            } -MockWith { "$testService loaded active running Regular background program processing daemon" }
+        }
+
+        It "Should be noncompliant with one Reason if we are expecting the service to be stopped" {
+            $nxService = [nxService]::new()
+            $nxService.Name = $testService
+            $nxService.Enabled = $true
+            $nxService.State = "Stopped"
+            $result = $nxService.Get()
+            $result.Reasons.Count | Should -Be 1
+            $result.Reasons[0].Code | Should -Be "nxService:nxService:State"
+            $result.Reasons[0].Phrase | Should -Be "The service '$testService' is present but we're expecting it to be 'Stopped' instead of 'Running'"
+            $nxService.Test() | Should -Be $false
+        }
+
+        It "Should be compliant if we are expecting the service to be running" {
+            $nxService = [nxService]::new()
+            $nxService.Name = $testService
+            $nxService.Enabled = $true
+            $nxService.State = "Running"
+            $result = $nxService.Get()
+            $result.Reasons.Count | Should -Be 0
+            $nxService.Test() | Should -Be $true
+        }
+
+        It "Should only return properties from the nxService class" {
+            $nxService = [nxService]::new()
+            $nxService.Name = $testService
+            $nxService.Enabled = $true
+            $nxService.State = "Running"
+            $result = $nxService.Get()
+            $expectedProperties = [nxService]::new().PSObject.Properties
+            $result.PSObject.Properties | ForEach-Object {
+                $_.Name | Should -BeIn $expectedProperties.Name
+            }
+            $expectedProperties.PSObject.Properties | ForEach-Object {
+                $_.Name | Should -BeIn $result.Name
+            }
+        }
+    }
+
+    Context "When the service is stopped" {
+        BeforeEach {
+            Mock -ModuleName 'nxtools' -CommandName 'Invoke-NativeCommand' -ParameterFilter {
+                $expected = @('list-units', '--type=service', '--no-legend', '--all', '--no-pager', $testService)
+                $diff = Compare-Object $Parameters $expected
+                return $Executable -eq "systemctl" -and $diff.Count -eq 0
+            } -MockWith { "$testService loaded inactive dead Regular background program processing daemon" }
+        }
+
+        It "Should be compliant if we are expecting the service to be stopped" {
+            $nxService = [nxService]::new()
+            $nxService.Name = $testService
+            $nxService.Enabled = $true
+            $nxService.State = "Stopped"
+            $result = $nxService.Get()
+            $result.Reasons.Count | Should -Be 0
+            $nxService.Test() | Should -Be $true
+        }
+
+        It "Should be noncompliant with one Reason if we are expecting the service to be running" {
+            $nxService = [nxService]::new()
+            $nxService.Name = $testService
+            $nxService.Enabled = $true
+            $nxService.State = "Running"
+            $result = $nxService.Get()
+            $result.Reasons.Count | Should -Be 1
+            $result.Reasons[0].Code | Should -Be "nxService:nxService:State"
+            $result.Reasons[0].Phrase | Should -Be "The service '$testService' is present but we're expecting it to be 'Running' instead of 'Stopped'"
+            $nxService.Test() | Should -Be $false
+        }
+    }
+}


### PR DESCRIPTION
#### Pull Request (PR) description

Fixed a bug in nxService where the Get-GuestConfigurationPackageComplianceStatus cmdlet from the GuestConfiguration module was throwing an unknown propertyName error. The GC agent was throwing this error because Get() was returning an object with more properties than what is defined in the nxService class.

#### This Pull Request (PR) fixes the following issues

- Fixes #25 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
