### PR TITLE
Fix nxFile not able to delete file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed nxFile not able to delete files.
+
+## [1.2.0] - 2023-09-08
+
+### Fixed
+
 - Fixed nxService causing an unknown propertyName error.
 
 ## [1.1.0] - 2023-07-18

--- a/source/Classes/1.DscResources/01.nxFile.ps1
+++ b/source/Classes/1.DscResources/01.nxFile.ps1
@@ -407,7 +407,7 @@ class nxFile
             $nxFileSystemInfo = Get-nxItem -Path $this.DestinationPath -ErrorAction Stop | Where-Object -FilterScript { $this.Type -eq $_.nxFileSystemItemType}
             if ($nxFileSystemInfo -and $currentState.Ensure -eq [Ensure]::Present)
             {
-                Remove-Item -Path $nxFileSystemInfo.DestinationPath -Force:($this.Force) -Recurse:($this.Recurse) -Confirm:$false
+                Remove-Item -Path $nxFileSystemInfo.FullName -Force:($this.Force) -Recurse:($this.Recurse) -Confirm:$false
             }
         }
     }

--- a/tests/Unit/Classes/DscResources/nxFile.tests.ps1
+++ b/tests/Unit/Classes/DscResources/nxFile.tests.ps1
@@ -1,0 +1,38 @@
+using module nxtools
+
+$script:mockPath = "/my/mock/file.txt" # Mock path for testing
+
+Describe "nxFile resource for managing a file or a folder" {
+    Context "When the file already exists" {
+        BeforeAll {
+            Mock -ModuleName 'nxtools' -CommandName 'Invoke-NativeCommand' -ParameterFilter {
+                $mockPathFound = $false
+                foreach ($param in $Parameters)
+                {
+                    if ($param -match $mockPath -or $param -match $mockPath.Replace('/', '\\'))
+                    {
+                        $mockPathFound = $true
+                    }
+                }
+                return $Executable -eq "ls" -and $mockPathFound
+            } -MockWith { "-rw-r--r-- 1 root root 0 2023-09-11 17:05:28.084507110 +0000 $mockPath" }
+        }
+
+        It "Should delete the file on remediation if we are expecting the file to be absent" {
+            $nxFile = [nxFile]::new()
+            $nxFile.Ensure = "Absent"
+            $nxFile.DestinationPath = $mockPath
+            $nxFile.Type = "File"
+            $nxFile.Mode = "0777"
+            $nxFile.Owner = "root"
+            $nxFile.Group = "root"
+
+            # Fail if Remove-Item is not called on remediation
+            Mock -ModuleName 'nxtools' -CommandName 'Remove-Item' -ParameterFilter {
+                return $Path -match $mockPath -or $Path -match $mockPath.Replace('/', '\\')
+            } -Verifiable
+            $nxFile.Set()
+            Should -InvokeVerifiable
+        }
+    }
+}


### PR DESCRIPTION
#### Pull Request (PR) description

The nxFile resource throws an error if you try to use it to delete a file.

`Remove-Item: Cannot bind argument to parameter 'Path' because it is null.`

The root cause is that $nxFileSystemInfo does not have a property named DestinationPath.

#### This Pull Request (PR) fixes the following issues

- Fixes #29 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
