### PR TITLE
Fix nxService crashing when service does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed nxFile not able to delete files.
+- Fixed nxService crashing when auditing a service that does not exist.
 - Fixed nxUser failing if any users in /etc/passwd have uppercase letters in their username.
 
 ## [1.2.0] - 2023-09-08

--- a/source/Classes/1.DscResources/07.nxService.ps1
+++ b/source/Classes/1.DscResources/07.nxService.ps1
@@ -34,7 +34,7 @@ class nxService
     [nxService] Get()
     {
         $nxService = Get-nxService -Name $this.Name
-        if ($null -eq $nxService.Name)
+        if ([string]::IsNullOrEmpty($nxService.Name))
         {
             # Silently return if the service does not exist
             Write-Warning -Message ('Service ''{0}'' could not be found.' -f $this.Name)

--- a/source/Classes/1.DscResources/07.nxService.ps1
+++ b/source/Classes/1.DscResources/07.nxService.ps1
@@ -40,7 +40,7 @@ class nxService
         $currentState.State = $nxService.State
         $currentState.Controller = $this.Controller
 
-        if (-not $currentState)
+        if (-not $currentState.Name)
         {
             # Silently return if the service does not exist
             Write-Warning -Message ('Service ''{0}'' could not be found.' -f $this.Name)
@@ -68,7 +68,7 @@ class nxService
         {
             'Enabled'
             {
-                if ($null -ne $this.enabled -and $currentState -and $this.Enabled -ne $currentState.Enabled)
+                if ($null -ne $this.enabled -and $this.Enabled -ne $currentState.Enabled)
                 {
                     $enabledReference = @{
                         $true = 'enabled'
@@ -84,7 +84,7 @@ class nxService
 
             'State'
             {
-                if ($null -ne $this.State -and $currentState -and $this.State -ne $currentState.State)
+                if ($null -ne $this.State -and $this.State -ne $currentState.State)
                 {
                     [Reason]@{
                         Code = '{0}:{0}:State' -f 'nxService'

--- a/source/Classes/1.DscResources/07.nxService.ps1
+++ b/source/Classes/1.DscResources/07.nxService.ps1
@@ -34,18 +34,18 @@ class nxService
     [nxService] Get()
     {
         $nxService = Get-nxService -Name $this.Name
-        $currentState = [nxService]::new()
-        $currentState.Name = $nxService.Name
-        $currentState.Enabled = $nxService.Enabled
-        $currentState.State = $nxService.State
-        $currentState.Controller = $this.Controller
-
-        if (-not $currentState.Name)
+        if ($null -eq $nxService.Name)
         {
             # Silently return if the service does not exist
             Write-Warning -Message ('Service ''{0}'' could not be found.' -f $this.Name)
             return [nxService]::new()
         }
+
+        $currentState = [nxService]::new()
+        $currentState.Name = $nxService.Name
+        $currentState.Enabled = $nxService.Enabled
+        $currentState.State = $nxService.State
+        $currentState.Controller = $this.Controller
 
         $valuesToCheck = @(
             'Enabled'

--- a/source/Classes/1.DscResources/07.nxService.ps1
+++ b/source/Classes/1.DscResources/07.nxService.ps1
@@ -34,14 +34,21 @@ class nxService
     [nxService] Get()
     {
         $nxService = Get-nxService -Name $this.Name
+        $currentState = [nxService]::new()
         if ([string]::IsNullOrEmpty($nxService.Name))
         {
-            # Silently return if the service does not exist
-            Write-Warning -Message ('Service ''{0}'' could not be found.' -f $this.Name)
-            return [nxService]::new()
+            if ($null -ne $this.Enabled -and -not $this.Enabled -and $null -ne $this.State -and $this.State -eq [nxServiceState]::Stopped)
+            {
+                return $currentState
+            }
+
+            $currentState.Reasons = [Reason]@{
+                Code = '{0}:{0}:NotRunning' -f 'nxService'
+                Phrase = 'Service ''{0}'' is not running.' -f $this.Name
+            }
+            return $currentState
         }
 
-        $currentState = [nxService]::new()
         $currentState.Name = $nxService.Name
         $currentState.Enabled = $nxService.Enabled
         $currentState.State = $nxService.State

--- a/source/Classes/1.DscResources/07.nxService.ps1
+++ b/source/Classes/1.DscResources/07.nxService.ps1
@@ -43,8 +43,8 @@ class nxService
             }
 
             $currentState.Reasons = [Reason]@{
-                Code = '{0}:{0}:NotRunning' -f 'nxService'
-                Phrase = 'Service ''{0}'' is not running.' -f $this.Name
+                Code = '{0}:{0}:NotRunningDNE' -f 'nxService'
+                Phrase = 'Service ''{0}'' is not running or does not exist.' -f $this.Name
             }
             return $currentState
         }
@@ -71,11 +71,11 @@ class nxService
 
         Write-Debug -Message 'Adding reasons to the current state to explain discrepancies...'
 
-        $currentState.reasons = switch ($compareState.Property)
+        $currentState.Reasons = switch ($compareState.Property)
         {
             'Enabled'
             {
-                if ($null -ne $this.enabled -and $this.Enabled -ne $currentState.Enabled)
+                if ($null -ne $this.Enabled -and $this.Enabled -ne $currentState.Enabled)
                 {
                     $enabledReference = @{
                         $true = 'enabled'
@@ -91,7 +91,7 @@ class nxService
 
             'State'
             {
-                if ($null -ne $this.State -and $this.State -ne $currentState.State)
+                if ($null -ne $this.State -and $this.State -ine $currentState.State)
                 {
                     [Reason]@{
                         Code = '{0}:{0}:State' -f 'nxService'


### PR DESCRIPTION
#### Pull Request (PR) description

The nxService resource crashes when auditing a service that does not exist. The if statement that was supposed to handle this case had the wrong condition.

#### This Pull Request (PR) fixes the following issues

- Fixes #30 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
