### PR TITLE
Fix nxUser regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed nxUser failing if any users in /etc/passwd have uppercase letters in their username.
+
+## [1.2.0] - 2023-09-08
+
+### Fixed
+
 - Fixed nxService causing an unknown propertyName error.
 
 ## [1.1.0] - 2023-07-18

--- a/source/Classes/nxEtcShadowEntry.ps1
+++ b/source/Classes/nxEtcShadowEntry.ps1
@@ -1,7 +1,7 @@
 class nxEtcShadowEntry
 {
     hidden static [regex] $EtcShadowLineParser = @(
-        '^(?<username>[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$))'
+        '^(?<username>[a-zA-Z_\.@]([a-zA-Z0-9_\.@-]{0,31}|[a-zA-Z0-9_\.@-]{0,30}\$))'
         '(?<password>[^:]*)'
         '(?<lastchanged>[^:]*)'
         '(?<min>[^:]*)'

--- a/source/Classes/nxLocalUser.ps1
+++ b/source/Classes/nxLocalUser.ps1
@@ -2,7 +2,7 @@ class nxLocalUser
 {
     # gcolas:x:1000:1000:,,,:/home/gcolas:/bin/bash
     static [regex] $PasswordLineParser = @(
-        '^(?<username>[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$))'
+        '^(?<username>[a-zA-Z_\.@]([a-zA-Z0-9_\.@-]{0,31}|[a-zA-Z0-9_\.@-]{0,30}\$))'
         '(?<password>[^:]+)'
         '(?<userid>[\d]+)'
         '(?<groupid>[\d]+)'

--- a/source/Public/usersAndGroups/Get-nxEtcShadow.ps1
+++ b/source/Public/usersAndGroups/Get-nxEtcShadow.ps1
@@ -44,7 +44,7 @@ function Get-nxEtcShadow
             {
                 Write-Debug -Message "[Get-nxEtcShadowEntry] Finding Local users by UserName '$userNameEntry'."
                 $allUsers | Where-Object -FilterScript {
-                    $_.username -eq $userNameEntry
+                    $_.username -ceq $userNameEntry
                 }
             }
         }

--- a/source/Public/usersAndGroups/Get-nxLocalUser.ps1
+++ b/source/Public/usersAndGroups/Get-nxLocalUser.ps1
@@ -44,7 +44,7 @@ function Get-nxLocalUser
             {
                 Write-Debug -Message "[Get-nxLocalUser] Finding Local users by UserName '$userNameEntry'."
                 $allUsers | Where-Object -FilterScript {
-                    $_.username -eq $userNameEntry
+                    $_.username -ceq $userNameEntry
                 }
             }
         }

--- a/tests/Unit/Classes/DscResources/nxUser.tests.ps1
+++ b/tests/Unit/Classes/DscResources/nxUser.tests.ps1
@@ -1,0 +1,76 @@
+using module nxtools
+
+Describe "nxUser resource for managing local users on a Linux node" {
+    Context "When the user exists" {
+        It ("Should accept all valid usernames") {
+            Mock -ModuleName 'nxtools' -CommandName 'Get-Content' -ParameterFilter {
+                return $Path -eq '/etc/passwd'
+            } -MockWith {
+                return @(
+                    "testuser:x:1000:1000::/home/testuser:/bin/bash",
+                    "Testuser:x:1001:1001::/home/Testuser:/bin/bash",
+                    "Testuser123:x:1002:1002::/home/Testuser123:/bin/bash",
+                    "Testuser:x:1001:1001::/home/Testuser:/bin/bash",
+                    "Testuser123:x:1002:1002::/home/Testuser123:/bin/bash",
+                    ".Testuser:x:1003:1003::/home/.Testuser:/bin/bash",
+                    ".Test.user:x:1004:1004::/home/.Test.user:/bin/bash",
+                    "_.Test.user:x:1005:1005::/home/_.Test.user:/bin/bash",
+                    "@_.Test.user:x:1006:1006::/home/@_.Test.user:/bin/bash",
+                    "@@_.Test.user:x:1007:1007::/home/@@_.Test.user:/bin/bash",
+                    "@@_.Test.user`$:x:1008:1008::/home/@@_.Test.user`$:/bin/bash",
+                    "_.@`$:x:1009:1009::/home/_.@`$:/bin/bash"
+                )
+            }
+
+            Mock -ModuleName 'nxtools' -CommandName 'Get-Content' -ParameterFilter {
+                return $Path -eq '/etc/shadow'
+            } -MockWith {
+                return @(
+                    "testuser:!:19613:0:99999:7:::",
+                    "Testuser:!:19613:0:99999:7:::",
+                    "Testuser123:!:19613:0:99999:7:::",
+                    ".Testuser:!:19613:0:99999:7:::",
+                    ".Test.user:!:19613:0:99999:7:::",
+                    "_.Test.user:!:19613:0:99999:7:::",
+                    "@_.Test.user:!:19613:0:99999:7:::",
+                    "@@_.Test.user:!:19613:0:99999:7:::",
+                    "@@_.Test.user`$:!:19613:0:99999:7:::",
+                    "_.@`$:!:19613:0:99999:7:::"
+                )
+            }
+
+            $nxUser = [nxUser]::new()
+            $nxUser.Ensure = "Present"
+            $nxUser.UserName = "testuser"
+            $result = $nxUser.Get()
+            $result.Reasons.Count | Should -Be 0
+            $nxUser.UserName = "Testuser"
+            $result = $nxUser.Get()
+            $result.Reasons.Count | Should -Be 0
+            $nxUser.UserName = "Testuser123"
+            $result = $nxUser.Get()
+            $result.Reasons.Count | Should -Be 0
+            $nxUser.UserName = ".Testuser"
+            $result = $nxUser.Get()
+            $result.Reasons.Count | Should -Be 0
+            $nxUser.UserName = ".Test.user"
+            $result = $nxUser.Get()
+            $result.Reasons.Count | Should -Be 0
+            $nxUser.UserName = "_.Test.user"
+            $result = $nxUser.Get()
+            $result.Reasons.Count | Should -Be 0
+            $nxUser.UserName = "@_.Test.user"
+            $result = $nxUser.Get()
+            $result.Reasons.Count | Should -Be 0
+            $nxUser.UserName = "@@_.Test.user"
+            $result = $nxUser.Get()
+            $result.Reasons.Count | Should -Be 0
+            $nxUser.UserName = "@@_.Test.user$"
+            $result = $nxUser.Get()
+            $result.Reasons.Count | Should -Be 0
+            $nxUser.UserName = "_.@$"
+            $result = $nxUser.Get()
+            $result.Reasons.Count | Should -Be 0
+        }
+    }
+}


### PR DESCRIPTION
#### Pull Request (PR) description

The nxUser resource fails if any users in /etc/passwd have uppercase letters in their username. According to the manpage for adduser,

_Historically, adduser and addgroup enforced conformity to IEEE Std 1003.1-2001, which allows only the following characters to appear in group and user names: letters, digits, underscores, periods, at signs (@) and dashes. The name may not start with a dash or @. The "$" sign is allowed at the end of usernames (to conform to samba)._
https://manpages.ubuntu.com/manpages/lunar/en/man5/adduser.conf.5.html

I was able to create usernames with capital letters and with periods, at signs, etc. as described in the statement above on Ubuntu 18. So, I'm updating the regex.

#### This Pull Request (PR) fixes the following issues

- Fixes #33 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
