### PR TITLE
Add mocks to Get-nxLsbRelease unit test

### DIFF
--- a/tests/Unit/Public/Get-nxLsbRelease.tests.ps1
+++ b/tests/Unit/Public/Get-nxLsbRelease.tests.ps1
@@ -1,5 +1,25 @@
-Describe 'Get-LsbRelease function' -skip:($IsWindows -or $IsMacOS) {
-    it 'should not throw (if the binary is installed)' {
-     {Get-nxLsbRelease} | Should -not -Throw
+Describe 'Get-LsbRelease function' {
+    Context "When the lsb-release package is installed" {
+        BeforeAll {
+            Mock -ModuleName 'nxtools' -CommandName 'Invoke-NativeCommand' -ParameterFilter {
+                return $Executable -eq "lsb_release"
+            } -MockWith {
+                return @(
+                    "No LSB modules are available.",
+                    "Distributor ID: Ubuntu",
+                    "Description:    Ubuntu 20.04.6 LTS",
+                    "Release:        20.04",
+                    "Codename:       focal"
+                )
+            }
+        }
+
+        It 'Should return information about the machine' {
+            $result = Get-nxLsbRelease
+            $result.DistributorID | Should -Be 'Ubuntu'
+            $result.Description | Should -Be 'Ubuntu 20.04.6 LTS'
+            $result.Release | Should -Be '20.04'
+            $result.Codename | Should -Be 'focal'
+        }
     }
 }

--- a/tests/Unit/Public/Get-nxLsbRelease.tests.ps1
+++ b/tests/Unit/Public/Get-nxLsbRelease.tests.ps1
@@ -1,7 +1,7 @@
-Describe 'Get-LsbRelease function' {
+Describe "Get-nxLsbRelease function" {
     Context "When the lsb-release package is installed" {
         BeforeAll {
-            Mock -ModuleName 'nxtools' -CommandName 'Invoke-NativeCommand' -ParameterFilter {
+            Mock -ModuleName "nxtools" -CommandName "Invoke-NativeCommand" -ParameterFilter {
                 return $Executable -eq "lsb_release"
             } -MockWith {
                 return @(
@@ -14,12 +14,12 @@ Describe 'Get-LsbRelease function' {
             }
         }
 
-        It 'Should return information about the machine' {
+        It "Should return information about the machine" {
             $result = Get-nxLsbRelease
-            $result.DistributorID | Should -Be 'Ubuntu'
-            $result.Description | Should -Be 'Ubuntu 20.04.6 LTS'
-            $result.Release | Should -Be '20.04'
-            $result.Codename | Should -Be 'focal'
+            $result.DistributorID | Should -Be "Ubuntu"
+            $result.Description | Should -Be "Ubuntu 20.04.6 LTS"
+            $result.Release | Should -Be "20.04"
+            $result.Codename | Should -Be "focal"
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

Updating the unit test for the Get-nxLsbRelease function to use mocks so that it's no longer dependent on Ubuntu. Without this, the unit test fails on Mariner.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).