### PR TITLE
Fix nxPackage crash when yum is picked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed nxPackage crashing when yum is picked as the package manager.
+
+## [1.3.0] - 2023-10-12
+
+### Fixed
+
 - Fixed nxFile not able to delete files.
 - Fixed nxService crashing when auditing a service that does not exist.
 - Fixed nxUser failing if any users in /etc/passwd have uppercase letters in their username.

--- a/source/Public/Packages/yum/Install-nxYumPackage.ps1
+++ b/source/Public/Packages/yum/Install-nxYumPackage.ps1
@@ -14,7 +14,11 @@ function Install-nxYumPackage
         [ValidateNotNullOrEmpty()]
         [string]
         # Specifc Version of a package that you want to find in the Cached list of packages.
-        $Version
+        $Version,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $Force
     )
 
     begin
@@ -25,7 +29,13 @@ function Install-nxYumPackage
     process
     {
         # Yum-get install
-        $yumGetInstallParams = @('install','-q','-y')
+        $yumGetInstallParams = @('install','-q')
+
+        if ($PSBoundParameters.ContainsKey('Force') -and $PSBoundParameters['Force'])
+        {
+            $yumGetInstallParams += @('-y')
+        }
+
         foreach ($packageName in $Name)
         {
             $packageToInstall = $packageName

--- a/tests/Unit/Classes/DscResources/nxPackage.tests.ps1
+++ b/tests/Unit/Classes/DscResources/nxPackage.tests.ps1
@@ -1,0 +1,62 @@
+using module nxtools
+
+$script:testPackage = "myTestPackage" # Mock package for testing
+
+Describe "nxPackage resource for managing packages on a Linux node" {
+    Context "When yum is used as the package manager" {
+        BeforeAll {
+            Mock -ModuleName 'nxtools' -CommandName 'Get-Command' -ParameterFilter { $Name -eq "yum" } -MockWith {
+                @{
+                    Name = "yum"
+                }
+            }
+        }
+
+        Context "When the package is not installed" {
+            BeforeAll {
+                Mock -ModuleName 'nxtools' -CommandName 'Invoke-NativeCommand' -ParameterFilter {
+                    $expected = @('list', 'installed', $testPackage, '--quiet')
+                    $diff = Compare-Object $Parameters $expected
+                    return $Executable -eq "yum" -and $diff.Count -eq 0
+                } -MockWith {
+                    $exception = New-Object System.Exception("Error: No matching Packages to list")
+                    return New-Object System.Management.Automation.ErrorRecord($exception, "errorId", "NotSpecified", $null)
+                }
+                Mock -ModuleName 'nxtools' -CommandName 'Invoke-NativeCommand' -ParameterFilter {
+                    $expected = @('install', '-q', '-y', $testPackage)
+                    $diff = Compare-Object $Parameters $expected
+                    return $Executable -eq "yum" -and $diff.Count -eq 0
+                } -MockWith {
+                    ""
+                }
+            }
+
+            It "Should be noncompliant with one Reason if we are expecting the package to be present" {
+                $nxPackage = [nxPackage]::new()
+                $nxPackage.Name = $testPackage
+                $nxPackage.Ensure = "Present"
+                $result = $nxPackage.Get()
+                $result.Reasons.Count | Should -Be 1
+                $result.Reasons[0].Code | Should -Be "nxPackage:nxPackage:Ensure"
+                $result.Reasons[0].Phrase | Should -Be "The nxPackage is not in desired state because the package was expected Present but was Absent."
+                $nxPackage.Test() | Should -Be $false
+            }
+
+            It "Should be compliant if we are expecting the package to be absent" {
+                $nxPackage = [nxPackage]::new()
+                $nxPackage.Name = $testPackage
+                $nxPackage.Ensure = "Absent"
+                $result = $nxPackage.Get()
+                $result.Reasons.Count | Should -Be 0
+                $nxPackage.Test() | Should -Be $true
+            }
+
+            It "Should install the package on remediation if we are expecting the package to be present" {
+                $nxPackage = [nxPackage]::new()
+                $nxPackage.Name = $testPackage
+                $nxPackage.Ensure = "Present"
+                $nxPackage.Set() # Should not throw
+            }
+        }
+    }
+}

--- a/tests/Unit/Classes/DscResources/nxPackage.tests.ps1
+++ b/tests/Unit/Classes/DscResources/nxPackage.tests.ps1
@@ -5,7 +5,7 @@ $script:testPackage = "myTestPackage" # Mock package for testing
 Describe "nxPackage resource for managing packages on a Linux node" {
     Context "When yum is used as the package manager" {
         BeforeAll {
-            Mock -ModuleName 'nxtools' -CommandName 'Get-Command' -ParameterFilter { $Name -eq "yum" } -MockWith {
+            Mock -ModuleName "nxtools" -CommandName "Get-Command" -ParameterFilter { $Name -eq "yum" } -MockWith {
                 @{
                     Name = "yum"
                 }
@@ -14,16 +14,16 @@ Describe "nxPackage resource for managing packages on a Linux node" {
 
         Context "When the package is not installed" {
             BeforeAll {
-                Mock -ModuleName 'nxtools' -CommandName 'Invoke-NativeCommand' -ParameterFilter {
-                    $expected = @('list', 'installed', $testPackage, '--quiet')
+                Mock -ModuleName "nxtools" -CommandName "Invoke-NativeCommand" -ParameterFilter {
+                    $expected = @("list", "installed", $testPackage, "--quiet")
                     $diff = Compare-Object $Parameters $expected
                     return $Executable -eq "yum" -and $diff.Count -eq 0
                 } -MockWith {
                     $exception = New-Object System.Exception("Error: No matching Packages to list")
                     return New-Object System.Management.Automation.ErrorRecord($exception, "errorId", "NotSpecified", $null)
                 }
-                Mock -ModuleName 'nxtools' -CommandName 'Invoke-NativeCommand' -ParameterFilter {
-                    $expected = @('install', '-q', '-y', $testPackage)
+                Mock -ModuleName "nxtools" -CommandName "Invoke-NativeCommand" -ParameterFilter {
+                    $expected = @("install", "-q", "-y", $testPackage)
                     $diff = Compare-Object $Parameters $expected
                     return $Executable -eq "yum" -and $diff.Count -eq 0
                 } -MockWith {


### PR DESCRIPTION
#### Pull Request (PR) description

nxPackage crashes when yum is picked as the package manager. This is due to a recent change #20 where a Force parameter was introduced. The Force parameter needed to be supported for yum just like it is for apt. Created unit tests to cover this path.

#### This Pull Request (PR) fixes the following issues

- Fixes #41

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).