### PR TITLE
Fix nxPackage crash when package not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed nxPackage crashing when yum is picked as the package manager.
+- Fixed nxPackage crashing when dpkg is picked as the package manager and the package is not installed.
 
 ## [1.3.0] - 2023-10-12
 

--- a/source/Public/Packages/dpkg/Get-nxDpkgPackage.ps1
+++ b/source/Public/Packages/dpkg/Get-nxDpkgPackage.ps1
@@ -44,19 +44,19 @@ function Get-nxDpkgPackage
                 AllowedPropertyName     = ([nxDpkgPackage].GetProperties().Name)
                 AddExtraPropertiesAsKey = 'AdditionalFields'
                 ErrorVariable           = 'packageError'
+                ErrorHandling           = { Write-Verbose $_ }
             }
 
             $properties = Invoke-NativeCommand -Executable 'dpkg' -Parameters $dpkgParams |
                 Get-PropertyHashFromListOutput @getPropertyHashFromListOutputParams
 
-            # Making sure we replicate the package property to Name property
-            # To correctly make the Base object (Package class)
-            #TODO: This should probably go in the nxDpkgPackage class constructors
-            $properties['PackageType'] = 'dpkg'
-            $properties.add('Name', $properties['Package'])
-
-            if (-not $packageError)
+            if (-not $packageError -and $null -ne $properties -and $properties.Count -ne 0)
             {
+                # Making sure we replicate the package property to Name property
+                # To correctly make the Base object (Package class)
+                #TODO: This should probably go in the nxDpkgPackage class constructors
+                $properties['PackageType'] = 'dpkg'
+                $properties.add('Name', $properties['Package'])
                 [nxDpkgPackage]$properties
             }
         }


### PR DESCRIPTION
#### Pull Request (PR) description

nxPackage crashes when dpkg is picked as the package manager and the package itself is not installed. To fix this, I'm updating nxPackage to properly handle when "dpkg --status \<package\>" returns error output. Created unit tests to cover this path.

#### This Pull Request (PR) fixes the following issues

- Fixes #45 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).