### PR TITLE
Fix nxPackage not handling status deinstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed nxPackage crashing when yum is picked as the package manager.
 - Fixed nxPackage crashing when dpkg is picked as the package manager and the package is not installed.
-- Fixed nxPackage not handling packages with status deinstall.
 
 ## [1.3.0] - 2023-10-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed nxPackage crashing when yum is picked as the package manager.
 - Fixed nxPackage crashing when dpkg is picked as the package manager and the package is not installed.
+- Fixed nxPackage not handling packages with status deinstall.
 
 ## [1.3.0] - 2023-10-12
 

--- a/source/Classes/1.DscResources/04.nxPackage.ps1
+++ b/source/Classes/1.DscResources/04.nxPackage.ps1
@@ -39,6 +39,11 @@ class nxPackage
             $packageFound = $packageFound[0]
         }
 
+        if ($packageFound -and $packageFound.Status -and $packageFound.Status.Contains("deinstall"))
+        {
+            $currentState.Ensure = [Ensure]::Absent
+        }
+
         $currentState.Name = $this.Name
         $currentState.PackageType = $packageFound.PackageType
         $currentState.Version = $packageFound.Version

--- a/source/Classes/1.DscResources/04.nxPackage.ps1
+++ b/source/Classes/1.DscResources/04.nxPackage.ps1
@@ -39,6 +39,12 @@ class nxPackage
             $packageFound = $packageFound[0]
         }
 
+        # TODO: Temporary fix, clean up packages with status deinstall
+        if ($packageFound -and $packageFound.Status -and $packageFound.Status.Contains("deinstall"))
+        {
+            $currentState.Ensure = [Ensure]::Absent
+        }
+
         $currentState.Name = $this.Name
         $currentState.PackageType = $packageFound.PackageType
         $currentState.Version = $packageFound.Version

--- a/source/Classes/1.DscResources/04.nxPackage.ps1
+++ b/source/Classes/1.DscResources/04.nxPackage.ps1
@@ -39,11 +39,6 @@ class nxPackage
             $packageFound = $packageFound[0]
         }
 
-        if ($packageFound -and $packageFound.Status -and $packageFound.Status.Contains("deinstall"))
-        {
-            $currentState.Ensure = [Ensure]::Absent
-        }
-
         $currentState.Name = $this.Name
         $currentState.PackageType = $packageFound.PackageType
         $currentState.Version = $packageFound.Version

--- a/source/Classes/1.DscResources/04.nxPackage.ps1
+++ b/source/Classes/1.DscResources/04.nxPackage.ps1
@@ -39,7 +39,6 @@ class nxPackage
             $packageFound = $packageFound[0]
         }
 
-        # TODO: Temporary fix, clean up packages with status deinstall
         if ($packageFound -and $packageFound.Status -and $packageFound.Status.Contains("deinstall"))
         {
             $currentState.Ensure = [Ensure]::Absent

--- a/source/Classes/1.DscResources/04.nxPackage.ps1
+++ b/source/Classes/1.DscResources/04.nxPackage.ps1
@@ -39,6 +39,7 @@ class nxPackage
             $packageFound = $packageFound[0]
         }
 
+        # TODO: Temporary fix, clean up packages with status deinstall
         if ($packageFound -and $packageFound.Status -and $packageFound.Status.Contains("deinstall"))
         {
             $currentState.Ensure = [Ensure]::Absent

--- a/tests/Unit/Classes/DscResources/nxPackage.tests.ps1
+++ b/tests/Unit/Classes/DscResources/nxPackage.tests.ps1
@@ -96,43 +96,5 @@ Describe "nxPackage resource for managing packages on a Linux node" {
                 $nxPackage.Test() | Should -Be $false
             }
         }
-
-        Context "When the package has status deinstall" {
-            BeforeAll {
-                Mock -ModuleName "nxtools" -CommandName "Invoke-NativeCommand" -ParameterFilter {
-                    $expected = @("-W", $testPackage)
-                    $diff = Compare-Object $Parameters $expected
-                    return $Executable -eq "dpkg-query" -and $diff.Count -eq 0
-                } -MockWith {
-                    "$testPackage`t"
-                }
-                Mock -ModuleName "nxtools" -CommandName "Get-nxPackage" -MockWith {
-                    return @{
-                        Package = $testPackage
-                        Status = "deinstall ok config-files"
-                    }
-                }
-            }
-
-            It "Should be noncompliant with one Reason if we are expecting the package to be present" {
-                $nxPackage = [nxPackage]::new()
-                $nxPackage.Name = $testPackage
-                $nxPackage.Ensure = "Present"
-                $result = $nxPackage.Get()
-                $result.Reasons.Count | Should -Be 1
-                $result.Reasons[0].Code | Should -Be "nxPackage:nxPackage:Ensure"
-                $result.Reasons[0].Phrase | Should -Be "The nxPackage is not in desired state because the package was expected Present but was Absent."
-                $nxPackage.Test() | Should -Be $false
-            }
-
-            It "Should be compliant if we are expecting the package to be absent" {
-                $nxPackage = [nxPackage]::new()
-                $nxPackage.Name = $testPackage
-                $nxPackage.Ensure = "Absent"
-                $result = $nxPackage.Get()
-                $result.Reasons.Count | Should -Be 0
-                $nxPackage.Test() | Should -Be $true
-            }
-        }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

nxPackage is not handling the case where a package has status deinstall. It considers a package to be installed if it has status deinstall. I made a temporary fix to address this issue and consider deinstall to be uninstalled.

More information on what deinstall means: https://manpages.ubuntu.com/manpages/noble/en/man1/dpkg.1.html
deinstall: The package is selected for deinstallation (i.e. we want to remove all files, except configuration files)

#### This Pull Request (PR) fixes the following issues

- Fixes #44 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).