### PR TITLE
Fix nxService reporting wrong status for Ubuntu 22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed module not working in PowerShell v7.4.x due to nxFileSystemInfo not implementing the abstract property Exists from the base type FileSystemInfo.
+- Fixed nxService reporting wrong status on Ubuntu Server 22.04 LTS due to incorrect parsing.
+
 ### Removed
 
 - configuration examples for password policies
+
+## [1.4.0] - 2024-02-08
 
 ### Fixed
 

--- a/source/Private/services/systemd/Get-nxSystemdService.ps1
+++ b/source/Private/services/systemd/Get-nxSystemdService.ps1
@@ -14,7 +14,7 @@ function Get-nxSystemdService
         throw 'systemctl not found'
     }
 
-    $systemctlParams = @('--type=service', '--no-legend', '--all', '--no-pager')
+    $systemctlParams = @('--type=service', '--no-legend', '--all', '--no-pager', '--plain')
     if ($PSBoundParameters.ContainsKey('Name'))
     {
         # Because systemctl version 219 and below do not support short name (i.e. centos 7.5)

--- a/tests/Unit/Classes/DscResources/nxService.tests.ps1
+++ b/tests/Unit/Classes/DscResources/nxService.tests.ps1
@@ -17,7 +17,7 @@ Describe "nxService resource for managing services on a Linux node" {
     Context "When the service is running" {
         BeforeAll {
             Mock -ModuleName 'nxtools' -CommandName 'Invoke-NativeCommand' -ParameterFilter {
-                $expected = @('list-units', '--type=service', '--no-legend', '--all', '--no-pager', $testService)
+                $expected = @('list-units', '--type=service', '--no-legend', '--all', '--no-pager', '--plain', $testService)
                 $diff = Compare-Object $Parameters $expected
                 return $Executable -eq "systemctl" -and $diff.Count -eq 0
             } -MockWith { "$testService loaded active running Regular background program processing daemon" }
@@ -64,7 +64,7 @@ Describe "nxService resource for managing services on a Linux node" {
     Context "When the service is stopped" {
         BeforeAll {
             Mock -ModuleName 'nxtools' -CommandName 'Invoke-NativeCommand' -ParameterFilter {
-                $expected = @('list-units', '--type=service', '--no-legend', '--all', '--no-pager', $testService)
+                $expected = @('list-units', '--type=service', '--no-legend', '--all', '--no-pager', '--plain', $testService)
                 $diff = Compare-Object $Parameters $expected
                 return $Executable -eq "systemctl" -and $diff.Count -eq 0
             } -MockWith { "$testService loaded inactive dead Regular background program processing daemon" }
@@ -102,7 +102,7 @@ Describe "nxService resource for managing services on a Linux node" {
             } -MockWith { "disabled" }
 
             Mock -ModuleName 'nxtools' -CommandName 'Invoke-NativeCommand' -ParameterFilter {
-                $expected = @('list-units', '--type=service', '--no-legend', '--all', '--no-pager', $testService)
+                $expected = @('list-units', '--type=service', '--no-legend', '--all', '--no-pager', '--plain', $testService)
                 $diff = Compare-Object $Parameters $expected
                 return $Executable -eq "systemctl" -and $diff.Count -eq 0
             } -MockWith { "" }


### PR DESCRIPTION
#### Pull Request (PR) description

On Ubuntu Server 22.04 LTS, nxService is reporting that services are not running when in fact they are. @eehret Found that this is caused by the output of a command we use having extra whitespace for Ubuntu 22+. Adding --plain to the command eliminates the extra whitespace and fixes the issue. I confirmed the fix by applying my own custom policy to a machine with and without the fix.

I also fixed CHANGELOG.md to include the latest release and a change that was merged last week.

#### This Pull Request (PR) fixes the following issues

- Fixes #54 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
