### PR TITLE
Fix nxGroup not removing group members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed module not working in PowerShell v7.4.x due to nxFileSystemInfo not implementing the abstract property Exists from the base type FileSystemInfo.
 - Fixed nxService reporting wrong status on Ubuntu Server 22.04 LTS due to incorrect parsing.
+- Fixed nxGroup not removing group members when specifying that the group should be empty.
 
 ### Removed
 

--- a/tests/Unit/Classes/DscResources/nxGroup.tests.ps1
+++ b/tests/Unit/Classes/DscResources/nxGroup.tests.ps1
@@ -1,0 +1,80 @@
+using module nxtools
+
+Describe "nxGroup resource for managing local groups and group members on a Linux node" {
+    Context "When the group exists with one member" {
+        BeforeAll {
+            Mock -ModuleName "nxtools" -CommandName "Get-Content" -ParameterFilter {
+                return $Path -eq "/etc/group"
+            } -MockWith {
+                return @(
+                    "root:x:0:",
+                    "users:x:100:"
+                    "foobar:x:1001:root"
+                )
+            }
+        }
+
+        Context "When there is a members mismatch" {
+            It ("Should be noncompliant") {
+                $nxGroup = [nxGroup]::new()
+                $nxGroup.Ensure = "Present"
+                $nxGroup.GroupName = "foobar"
+                $nxGroup.Members = @("root", "testuser")
+                $result = $nxGroup.Get()
+                $result.Reasons.Count | Should -Be 1
+                $result.Reasons[0].Phrase | Should -Be "The members for Group 'foobar' do not match. It's missing 'testuser' and has the extra ''."
+                $nxGroup.Test() | Should -Be $false
+            }
+
+            It ("Should update group members on remediation") {
+                $nxGroup = [nxGroup]::new()
+                $nxGroup.Ensure = "Present"
+                $nxGroup.GroupName = "foobar"
+                $nxGroup.Members = @("root", "testuser")
+
+                Mock -ModuleName 'nxtools' -CommandName 'Invoke-NativeCommand' -ParameterFilter {
+                    $expected = @("-M", "root,testuser", "foobar")
+                    $diff = Compare-Object $Parameters $expected
+                    return $Executable -eq "gpasswd" -and $diff.Count -eq 0
+                } -Verifiable
+                $nxGroup.Set() # Should not throw
+                Should -InvokeVerifiable
+            }
+        }
+
+        Context "When the desired value for members is no members" {
+            It ("Should be noncompliant") {
+                $nxGroup = [nxGroup]::new()
+                $nxGroup.Ensure = "Present"
+                $nxGroup.GroupName = "foobar"
+                # PowerShell converts Members to null when it's an empty array in the configuration
+                $nxGroup.Members = $null
+                $result = $nxGroup.Get()
+                # When Members is null, group members aren't checked
+                $result.Reasons.Count | Should -Be 0
+                $nxGroup.Test() | Should -Be $true
+                $nxGroup.Force = $true
+                $result = $nxGroup.Get()
+                $result.Reasons.Count | Should -Be 1
+                $result.Reasons[0].Phrase | Should -Be "The members for Group 'foobar' do not match. It's missing '' and has the extra 'root'."
+                $nxGroup.Test() | Should -Be $false
+            }
+
+            It ("Should remove all group members on remediation") {
+                $nxGroup = [nxGroup]::new()
+                $nxGroup.Ensure = "Present"
+                $nxGroup.GroupName = "foobar"
+                $nxGroup.Members = $null
+                $nxGroup.Force = $true
+
+                Mock -ModuleName 'nxtools' -CommandName 'Invoke-NativeCommand' -ParameterFilter {
+                    $expected = @("-d", "root", "foobar")
+                    $diff = Compare-Object $Parameters $expected
+                    return $Executable -eq "gpasswd" -and $diff.Count -eq 0
+                } -Verifiable
+                $nxGroup.Set() # Should not throw
+                Should -InvokeVerifiable
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Pull Request (PR) description

If a group exists with some members, the nxGroup resource is reporting compliant and not removing the members when the Members property is set to an empty array. The root cause of this is that PowerShell is converting the empty array to null which causes the Members property to not be checked at all. This PR fixes the issue by introducing a Force property where if Force is true and the Members property is null, Members will be set to an empty list forcing the actual and desired values to be compared instead of ignored.

Set logic was updated for this use case as well because the gpasswd command does not support removing all members from a group with just the -M option. The workaround is to remove members instead.

#### This Pull Request (PR) fixes the following issues

- Fixes #53 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
