### PR TITLE
Improve /etc/shadow parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Improved /etc/shadow file parsing for the nxUser resource.
+
+## [1.5.0] - 2025-01-28
+
+### Fixed
+
 - Fixed module not working in PowerShell v7.4.x due to nxFileSystemInfo not implementing the abstract property Exists from the base type FileSystemInfo.
 - Fixed nxService reporting wrong status on Ubuntu Server 22.04 LTS due to incorrect parsing.
 - Fixed nxGroup not removing group members when specifying that the group should be empty.

--- a/source/Classes/nxEtcShadowEntry.ps1
+++ b/source/Classes/nxEtcShadowEntry.ps1
@@ -15,12 +15,12 @@ class nxEtcShadowEntry
     hidden [string] $ShadowEntry
     [string] $Username
     [string] $EncryptedPassword # as in the Shadow file
-    [datetime] $PasswordLastChanged
-    [int] $MinimumPasswordAgeInDays
-    [int] $MaximumPasswordAgeInDays
-    [int] $PasswordAgeWarningPeriodInDays
-    [int] $PasswordInactivityPeriodInDays
-    [System.Nullable[datetime]] $AccountExipreOn
+    [Nullable[datetime]] $PasswordLastChanged
+    [Nullable[int]] $MinimumPasswordAgeInDays
+    [Nullable[int]] $MaximumPasswordAgeInDays
+    [Nullable[int]] $PasswordAgeWarningPeriodInDays
+    [Nullable[int]] $PasswordInactivityPeriodInDays
+    [Nullable[datetime]] $AccountExipreOn
     [string] $ReservedField
 
     nxEtcShadowEntry()
@@ -39,16 +39,12 @@ class nxEtcShadowEntry
         $this.ShadowEntry = $EtcShadowEntry
         $this.Username = $Matches.username
         $this.EncryptedPassword = $Matches.password
-        $this.PasswordLastChanged = ([datetime]'1/1/1970').AddDays($Matches.lastchanged)
-        $this.MinimumPasswordAgeInDays = $Matches.min
-        $this.MaximumPasswordAgeInDays = $Matches.max
-        $this.PasswordAgeWarningPeriodInDays = $Matches.warn
-        $this.PasswordInactivityPeriodInDays = $Matches.inactive
-        if ($Matches.expire)
-        {
-            $this.AccountExipreOn = ([datetime]'1/1/1970').AddDays($Matches.expire)
-        }
-
+        $this.PasswordLastChanged = $this.ParseDateTime($Matches.lastchanged)
+        $this.MinimumPasswordAgeInDays = $this.ParseInt($Matches.min)
+        $this.MaximumPasswordAgeInDays = $this.ParseInt($Matches.max)
+        $this.PasswordAgeWarningPeriodInDays = $this.ParseInt($Matches.warn)
+        $this.PasswordInactivityPeriodInDays = $this.ParseInt($Matches.inactive)
+        $this.AccountExipreOn = $this.ParseDateTime($Matches.expire)
         $this.ReservedField = $Matches.other
 
         $this | Add-Member -MemberType ScriptProperty -Name 'PasswordLocked' -Value {
@@ -71,5 +67,27 @@ class nxEtcShadowEntry
         {
             return $false
         }
+    }
+
+    [Nullable[int]] ParseInt([string] $value)
+    {
+        if ([string]::IsNullOrEmpty($value))
+        {
+            return $null
+        }
+
+        # Throws if the value is not a valid integer
+        return [int]::Parse($value)
+    }
+
+    [Nullable[datetime]] ParseDateTime([string] $value)
+    {
+        if ([string]::IsNullOrEmpty($value))
+        {
+            return $null
+        }
+
+        # Throws if the value is not a valid integer
+        return ([datetime]'1/1/1970').AddDays([int]::Parse($value))
     }
 }

--- a/tests/Unit/Classes/DscResources/nxUser.tests.ps1
+++ b/tests/Unit/Classes/DscResources/nxUser.tests.ps1
@@ -72,5 +72,73 @@ Describe "nxUser resource for managing local users on a Linux node" {
             $result = $nxUser.Get()
             $result.Reasons.Count | Should -Be 0
         }
+
+        It ("Should handle some invalid values in /etc/shadow") {
+            Mock -ModuleName 'nxtools' -CommandName 'Get-Content' -ParameterFilter {
+                return $Path -eq '/etc/passwd'
+            } -MockWith {
+                return @(
+                    "testuser1:x:1000:1000::/home/testuser:/bin/bash",
+                    "testuser2:x:1000:1000::/home/testuser:/bin/bash",
+                    "testuser3:x:1000:1000::/home/testuser:/bin/bash",
+                    "testuser4:x:1000:1000::/home/testuser:/bin/bash",
+                    "testuser5:x:1000:1000::/home/testuser:/bin/bash",
+                    "testuser6:x:1000:1000::/home/testuser:/bin/bash"
+                )
+            }
+
+            Mock -ModuleName 'nxtools' -CommandName 'Get-Content' -ParameterFilter {
+                return $Path -eq '/etc/shadow'
+            } -MockWith {
+                # The '!' character is not allowed in fields where a number is expected
+                return @(
+                    "testuser1:abc123:!:0:99999:7:::",
+                    "testuser2:!:19613:!:99999:7:::",
+                    "testuser3:!:19613:0:!:7:::",
+                    "testuser4:!:19613:0:99999:!:::",
+                    "testuser5:!:19613:0:99999:7:!::",
+                    "testuser6:!:19613:0:99999:7::!:"
+                )
+            }
+
+            $nxUser = [nxUser]::new()
+            $nxUser.Ensure = "Present"
+            $nxUser.UserName = "testuser1"
+            { $nxUser.Get() } | Should -Throw
+            $nxUser.UserName = "testuser2"
+            { $nxUser.Get() } | Should -Throw
+            $nxUser.UserName = "testuser3"
+            { $nxUser.Get() } | Should -Throw
+            $nxUser.UserName = "testuser4"
+            { $nxUser.Get() } | Should -Throw
+            $nxUser.UserName = "testuser5"
+            { $nxUser.Get() } | Should -Throw
+            $nxUser.UserName = "testuser6"
+            { $nxUser.Get() } | Should -Throw
+        }
+
+        It ("Should handle some empty values in /etc/shadow") {
+            Mock -ModuleName 'nxtools' -CommandName 'Get-Content' -ParameterFilter {
+                return $Path -eq '/etc/passwd'
+            } -MockWith {
+                return @(
+                    "testuser:x:1000:1000::/home/testuser:/bin/bash"
+                )
+            }
+
+            Mock -ModuleName 'nxtools' -CommandName 'Get-Content' -ParameterFilter {
+                return $Path -eq '/etc/shadow'
+            } -MockWith {
+                return @(
+                    "testuser:abc123:::::::"
+                )
+            }
+
+            $nxUser = [nxUser]::new()
+            $nxUser.Ensure = "Present"
+            $nxUser.UserName = "testuser"
+            $result = $nxUser.Get()
+            $result.Reasons.Count | Should -Be 0
+        }
     }
 }

--- a/tests/Unit/Classes/DscResources/nxUser.tests.ps1
+++ b/tests/Unit/Classes/DscResources/nxUser.tests.ps1
@@ -93,11 +93,11 @@ Describe "nxUser resource for managing local users on a Linux node" {
                 # The '!' character is not allowed in fields where a number is expected
                 return @(
                     "testuser1:abc123:!:0:99999:7:::",
-                    "testuser2:!:19613:!:99999:7:::",
-                    "testuser3:!:19613:0:!:7:::",
-                    "testuser4:!:19613:0:99999:!:::",
-                    "testuser5:!:19613:0:99999:7:!::",
-                    "testuser6:!:19613:0:99999:7::!:"
+                    "testuser2:abc123:19613:!:99999:7:::",
+                    "testuser3:abc123:19613:0:!:7:::",
+                    "testuser4:abc123:19613:0:99999:!:::",
+                    "testuser5:abc123:19613:0:99999:7:!::",
+                    "testuser6:abc123:19613:0:99999:7::!:"
                 )
             }
 


### PR DESCRIPTION
#### Pull Request (PR) description

A customer reported an issue where the nxUser resource was failing to parse an entry in /etc/shadow. The entry had a '!' character for the last password change field. That entry is invalid because that field should be a number not a string. However, the error message is not helpful.

`Cannot convert argument "value", with value: "!", for "AddDays" to type "System.Double"`

This change adds some validation for the numeric fields of /etc/shadow. We will still throw an error when a given entry is invalid, but the error will be more readable.

#### This Pull Request (PR) fixes the following issues

N/A

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).