### PR TITLE
Fix nxFile AccessRight parameter validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Improved /etc/shadow file parsing for the nxUser resource.
+- Fixed a validation error related to an 'AccessRight' parameter when a file has empty permissions for one or more categories.
 
 ## [1.5.0] - 2025-01-28
 

--- a/source/Private/nxFileSystem/Convert-nxFileSystemAccessRightToSymbol.ps1
+++ b/source/Private/nxFileSystem/Convert-nxFileSystemAccessRightToSymbol.ps1
@@ -5,7 +5,7 @@ function Convert-nxFileSystemAccessRightToSymbol
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [System.String[]]
-        [ValidateScript({$_ -as [nxFileSystemAccessRight] -or $_ -as [nxFileSystemSpecialMode]})]
+        [ValidateScript({$null -ne ($_ -as [nxFileSystemAccessRight]) -or $null -ne ($_ -as [nxFileSystemSpecialMode])})]
         $AccessRight,
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]
@@ -26,11 +26,11 @@ function Convert-nxFileSystemAccessRightToSymbol
         [nxFileSystemSpecialMode]$SpecialModeEntry = 'none'
 
         $AccessRight.ForEach({
-            if ($_ -as [nxFileSystemAccessRight])
+            if ($null -ne ($_ -as [nxFileSystemAccessRight]))
             {
                 $AccessRightEntry = $AccessRightEntry -bor [nxFileSystemAccessRight]$_
             }
-            elseif ($_ -as [nxFileSystemSpecialMode])
+            elseif ($null -ne ($_ -as [nxFileSystemSpecialMode]))
             {
                 $SpecialModeEntry = $SpecialModeEntry -bor [nxFileSystemSpecialMode]$_
             }

--- a/source/Private/nxFileSystem/Convert-nxFileSystemModeComparisonToSymbolicOperation.ps1
+++ b/source/Private/nxFileSystem/Convert-nxFileSystemModeComparisonToSymbolicOperation.ps1
@@ -11,7 +11,7 @@ function Convert-nxFileSystemModeComparisonToSymbolicOperation
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [System.String]
-        [ValidateScript({$_ -as [nxFileSystemAccessRight] -or $_ -as [nxFileSystemSpecialMode]})]
+        [ValidateScript({$null -ne ($_ -as [nxFileSystemAccessRight]) -or $null -ne ($_ -as [nxFileSystemSpecialMode])})]
         [Alias('InputObject')]
         $EnumValue,
 

--- a/tests/Unit/Classes/DscResources/nxFile.tests.ps1
+++ b/tests/Unit/Classes/DscResources/nxFile.tests.ps1
@@ -35,4 +35,29 @@ Describe "nxFile resource for managing a file or a folder" {
             Should -InvokeVerifiable
         }
     }
+
+    Context "When the file already exists but has empty permissions for the other category" {
+        BeforeAll {
+            Mock -ModuleName 'nxtools' -CommandName 'Invoke-NativeCommand' -ParameterFilter {
+                $mockPathFound = $false
+                foreach ($param in $Parameters)
+                {
+                    if ($param -match $mockPath -or $param -match $mockPath.Replace('/', '\\'))
+                    {
+                        $mockPathFound = $true
+                    }
+                }
+                return $Executable -eq "ls" -and $mockPathFound
+            } -MockWith { "-rw-r----- 1 root root 0 2023-09-11 17:05:28.084507110 +0000 $mockPath" }
+        }
+
+        It "Should be compliant if we are only expecting the file to exist" {
+            $nxFile = [nxFile]::new()
+            $nxFile.Ensure = "Present"
+            $nxFile.DestinationPath = $mockPath
+            $nxFile.Type = "File"
+            $result = $nxFile.Get()
+            $result.Reasons.Count | Should -Be 0
+        }
+    }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

Fixes a validation error from the nxFile resource related to an 'AccessRight' parameter.

> Cannot validate argument on parameter 'AccessRight'. The '$_ -as [nxFileSystemAccessRight] -or $_ -as [nxFileSystemSpecialMode]' validation script for the argument with value 'None' did not return a result of True.

When a file has empty permissions, `---`, for a category, the nxFile resource parses the permissions as an enum value `[nxFileSystemAccessRight]::None` which has a numeric value of 0. The validation expression, `$_ -as [nxFileSystemAccessRight] -or $_ -as [nxFileSystemSpecialMode]` relies on the truthiness of the cast result. Since both `None` enum members have a value of 0, and 0 is falsy in PowerShell, the expression evaluated to `0 -or 0` which returns `$false`, causing validation to fail even though the cast was successful. To fix this, the validation expression explicitly checks if the cast returns null instead of relying on truthiness.

#### This Pull Request (PR) fixes the following issues

- Fixes #34

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
