### PR TITLE
Fix nxUser set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Improved /etc/shadow file parsing for the nxUser resource.
+- For the nxUser resource, improved /etc/shadow file parsing.
 - Fixed a validation error related to an 'AccessRight' parameter when a file has empty permissions for one or more categories.
+- For the nxUser resource, fixed set not working when the user already exists.
+- For the nxUser resource, fixed set creating a user with the wrong encrypted password.
 
 ## [1.5.0] - 2025-01-28
 

--- a/source/Classes/1.DscResources/03.nxUser.ps1
+++ b/source/Classes/1.DscResources/03.nxUser.ps1
@@ -99,7 +99,7 @@ class nxUser
                 {
                     [Reason]@{
                         Code = '{0}:{0}:FullName' -f $this.GetType()
-                        Phrase = $script:localizedDataNxUser.FullNameMismatch -f $this.FullName, $currentState.FullName
+                        Phrase = $script:localizedDataNxUser.FullNameMismatch -f $this.UserName, $currentState.FullName
                     }
                 }
 
@@ -107,7 +107,7 @@ class nxUser
                 {
                     [Reason]@{
                         Code = '{0}:{0}:Description' -f $this.GetType()
-                        Phrase = $script:localizedDataNxUser.DescriptionMismatch -f $this.Description, $currentState.Description
+                        Phrase = $script:localizedDataNxUser.DescriptionMismatch -f $this.UserName, $currentState.Description
                     }
                 }
 
@@ -115,7 +115,7 @@ class nxUser
                 {
                     [Reason]@{
                         Code = '{0}:{0}:Password' -f $this.GetType()
-                        Phrase = $script:localizedDataNxUser.PasswordMismatch -f $this.Password, $currentState.Password
+                        Phrase = $script:localizedDataNxUser.PasswordMismatch -f $this.UserName, $currentState.Password
                     }
                 }
 
@@ -123,7 +123,7 @@ class nxUser
                 {
                     [Reason]@{
                         Code = '{0}:{0}:Disabled' -f $this.GetType()
-                        Phrase = $script:localizedDataNxUser.DisabledMismatch -f $this.Disabled, $currentState.Disabled
+                        Phrase = $script:localizedDataNxUser.DisabledMismatch -f $this.UserName, $currentState.Disabled
                     }
                 }
 
@@ -131,7 +131,7 @@ class nxUser
                 {
                     [Reason]@{
                         Code = '{0}:{0}:PasswordChangeRequired' -f $this.GetType()
-                        Phrase = $script:localizedDataNxUser.PasswordChangeRequiredMismatch -f $this.PasswordChangeRequired, $currentState.PasswordChangeRequired
+                        Phrase = $script:localizedDataNxUser.PasswordChangeRequiredMismatch -f $this.UserName, $this.PasswordChangeRequired, $currentState.PasswordChangeRequired
                     }
                 }
 
@@ -139,7 +139,7 @@ class nxUser
                 {
                     [Reason]@{
                         Code = '{0}:{0}:HomeDirectory' -f $this.GetType()
-                        Phrase = $script:localizedDataNxUser.HomeDirectoryMismatch -f $this.HomeDirectory, $currentState.HomeDirectory
+                        Phrase = $script:localizedDataNxUser.HomeDirectoryMismatch -f $this.UserName, $this.HomeDirectory, $currentState.HomeDirectory
                     }
                 }
 
@@ -147,7 +147,7 @@ class nxUser
                 {
                     [Reason]@{
                         Code = '{0}:{0}:GroupID' -f $this.GetType()
-                        Phrase = $script:localizedDataNxUser.GroupIDMismatch -f $this.GroupID, $currentState.GroupID
+                        Phrase = $script:localizedDataNxUser.GroupIDMismatch -f $this.UserName, $this.GroupID, $currentState.GroupID
                     }
                 }
             }
@@ -238,7 +238,9 @@ class nxUser
 
                 # Get user so we can set other properties
                 $localUser = Get-nxLocalUser -UserName $this.UserName -ErrorAction Stop
-                $setUserParams = @{}
+                $setUserParams = @{
+                    UserName = $this.UserName
+                }
 
                 switch -Regex ($currentState.Reasons.Code)
                 {

--- a/source/Public/usersAndGroups/New-nxLocalUser.ps1
+++ b/source/Public/usersAndGroups/New-nxLocalUser.ps1
@@ -178,7 +178,7 @@ function New-nxLocalUser
 
         if ($PSBoundParameters.ContainsKey('EncryptedPassword') -and $PSBoundParameters['EncryptedPassword'])
         {
-            $userAddParams += @('-p', $EncryptedPassword)
+            $userAddParams += @('-p', ($EncryptedPassword | Get-nxEscapedString))
         }
 
         if ($PSBoundParameters.ContainsKey('ShellCommand') -and $PSBoundParameters['ShellCommand'])

--- a/tests/Unit/Classes/DscResources/nxUser.tests.ps1
+++ b/tests/Unit/Classes/DscResources/nxUser.tests.ps1
@@ -140,5 +140,90 @@ Describe "nxUser resource for managing local users on a Linux node" {
             $result = $nxUser.Get()
             $result.Reasons.Count | Should -Be 0
         }
+
+        It ("Should be able to set the password") {
+            Mock -ModuleName 'nxtools' -CommandName 'Get-Content' -ParameterFilter {
+                return $Path -eq '/etc/passwd'
+            } -MockWith {
+                return @(
+                    "testuser:x:1000:1000::/home/testuser:/bin/bash"
+                )
+            }
+
+            Mock -ModuleName 'nxtools' -CommandName 'Get-Content' -ParameterFilter {
+                return $Path -eq '/etc/shadow'
+            } -MockWith {
+                return @(
+                    "testuser:password:::::::"
+                )
+            }
+
+            $nxUser = [nxUser]::new()
+            $nxUser.Ensure = "Present"
+            $nxUser.UserName = "testuser"
+            $nxUser.Password = "newPassword"
+            $result = $nxUser.Get()
+            $result.Reasons.Count | Should -Be 1
+            $result.Reasons[0].Code | Should -Be "nxUser:nxUser:Password"
+            $result.Reasons[0].Phrase | Should -Be "The nxLocalUser with UserName 'testuser' has an unexpected Password."
+            $nxUser.Test() | Should -Be $false
+
+            Mock -ModuleName "nxtools" -CommandName "Invoke-NativeCommand" -ParameterFilter {
+                return $Executable -eq "usermod"
+            }
+
+            $nxUser.Set()
+            
+            Should -Invoke -CommandName "Invoke-NativeCommand" -ModuleName "nxtools" -ParameterFilter {
+                return $Executable -eq "usermod" -and 
+                       $Parameters.Count -eq 3 -and 
+                       $Parameters[0] -eq "-p" -and 
+                       $Parameters[1] -eq "'newPassword'" -and 
+                       $Parameters[2] -eq "testuser"
+            } -Times 1 -Exactly
+        }
+    }
+
+    Context "When the user does not exist" {
+        BeforeAll {
+            Mock -ModuleName 'nxtools' -CommandName 'Get-Content' -ParameterFilter {
+                return $Path -eq '/etc/passwd'
+            } -MockWith {
+                return @()
+            }
+            
+            Mock -ModuleName 'nxtools' -CommandName 'Get-Content' -ParameterFilter {
+                return $Path -eq '/etc/shadow'
+            } -MockWith {
+                return @()
+            }
+        }
+
+        It ("Should be able to create a user where the encrypted password contains dollar signs") {
+            $nxUser = [nxUser]::new()
+            $nxUser.Ensure = "Present"
+            $nxUser.UserName = "testuser"
+            $nxUser.Password = "pa`$`$word"
+            $result = $nxUser.Get()
+            $result.Reasons.Count | Should -Be 1
+            $result.Reasons[0].Code | Should -Be "nxUser:nxUser:Ensure"
+            $result.Reasons[0].Phrase | Should -Be "The nxLocalUser with UserName 'testuser' was not found but is expected to be present."
+            $nxUser.Test() | Should -Be $false
+
+            Mock -ModuleName "nxtools" -CommandName "Invoke-NativeCommand" -ParameterFilter {
+                return $Executable -eq "useradd"
+            }
+
+            $nxUser.Set()
+
+            Should -Invoke -CommandName "Invoke-NativeCommand" -ModuleName "nxtools" -ParameterFilter {
+                return $Executable -eq "useradd" -and 
+                       $Parameters.Count -eq 4 -and 
+                       $Parameters[0] -eq "-p" -and 
+                       $Parameters[1] -eq "'pa`$`$word'" -and 
+                       $Parameters[2] -eq "-U" -and
+                       $Parameters[3] -eq "testuser"
+            } -Times 1 -Exactly
+        }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

Fixed a few issues related to nxUser set.

* Fixed set not working when the user already exists. The username wasn't being passed to the usermod command.
* Fixed formatting for some of the error messages. The messages were expecting a username not the property value.
* Fixed set not creating a user with the correct encrypted password if the encrypted password contained dollar signs. The value needed to be escaped.

#### This Pull Request (PR) fixes the following issues

- Fixes #63

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
